### PR TITLE
サイト複製機能 ネームスペースの修正

### DIFF
--- a/app/models/concerns/sys/site_copy/article.rb
+++ b/app/models/concerns/sys/site_copy/article.rb
@@ -135,7 +135,7 @@ module Sys::SiteCopy::Article
           end
 
           if cms_page2.route == "facility/page"
-            new_cms_page2.category_ids = pase_checkboxes_for_dupcms(node_pg_cats, "merge", cms_page2.category_ids)
+            new_cms_page2.category_ids = Sys::SiteCopy::Checkboxes.pase_checkboxes_for_dupcms(node_pg_cats, "merge", cms_page2.category_ids)
           end
 
           new_cms_page2.save!

--- a/app/models/concerns/sys/site_copy/article.rb
+++ b/app/models/concerns/sys/site_copy/article.rb
@@ -1,4 +1,4 @@
-module Sys::SiteCopyArticle
+module Sys::SiteCopy::Article
   private
 #記事・その他ページ
     def self.copy_article(site_old, site, node_pg_cats, layout_records_map)

--- a/app/models/concerns/sys/site_copy/checkboxes.rb
+++ b/app/models/concerns/sys/site_copy/checkboxes.rb
@@ -1,4 +1,4 @@
-module Sys::SiteCopyCheckboxes
+module Sys::SiteCopy::Checkboxes
   private
     @@node_fac_cat_routes = ["facility/location", "facility/category", "facility/service"]
     @@node_copied_fac_cat_routes = ["facility/search", "facility/node"]

--- a/app/models/concerns/sys/site_copy/cms_layout.rb
+++ b/app/models/concerns/sys/site_copy/cms_layout.rb
@@ -1,4 +1,4 @@
-module Sys::SiteCopyCmsLayout
+module Sys::SiteCopy::CmsLayout
   private
     @layout_records_map = {}
 #レイアウト:OK

--- a/app/models/concerns/sys/site_copy/cms_pages.rb
+++ b/app/models/concerns/sys/site_copy/cms_pages.rb
@@ -1,4 +1,4 @@
-module Sys::SiteCopyCmsPages
+module Sys::SiteCopy::CmsPages
   private
 #固定ページ:OK
     def self.copy_cms_pages(site_old, site)

--- a/app/models/concerns/sys/site_copy/cms_parts.rb
+++ b/app/models/concerns/sys/site_copy/cms_parts.rb
@@ -1,4 +1,4 @@
-module Sys::SiteCopyCmsParts
+module Sys::SiteCopy::CmsParts
   private
 #パーツ:OK
 # NOTE:cms_part.dup だと失敗する

--- a/app/models/concerns/sys/site_copy/dictionaries.rb
+++ b/app/models/concerns/sys/site_copy/dictionaries.rb
@@ -1,4 +1,4 @@
-module Sys::SiteCopyDictionaries
+module Sys::SiteCopy::Dictionaries
   private
 #かな辞書:OK
     def self.copy_dictionaries(site_old, site)

--- a/app/models/concerns/sys/site_copy/files.rb
+++ b/app/models/concerns/sys/site_copy/files.rb
@@ -1,4 +1,4 @@
-module Sys::SiteCopyFiles
+module Sys::SiteCopy::Files
   private
 #共有ファイル:OK
 # 元サイトから共有ファイルを全て複製サイトへ複製

--- a/app/models/concerns/sys/site_copy/nodes.rb
+++ b/app/models/concerns/sys/site_copy/nodes.rb
@@ -120,13 +120,13 @@ module Sys::SiteCopy::Nodes
     def self.set_cstm_attrs(base_cmsnode, new_site, node_fac_cats, new_cmsnode_attrs)
         # 施設の種類・用途・地域
         if base_cmsnode.route == "facility/page"
-          new_cmsnode_attrs[:category_ids] = Sys::SiteCopyCheckboxes.pase_checkboxes_for_dupcms(
+          new_cmsnode_attrs[:category_ids] = Sys::SiteCopy::Checkboxes.pase_checkboxes_for_dupcms(
             node_fac_cats, "facility/category", base_cmsnode.category_ids
           )
-          new_cmsnode_attrs[:service_ids] = Sys::SiteCopyCheckboxes.pase_checkboxes_for_dupcms(
+          new_cmsnode_attrs[:service_ids] = Sys::SiteCopy::Checkboxes.pase_checkboxes_for_dupcms(
             node_fac_cats, "facility/service", base_cmsnode.service_ids
           )
-          new_cmsnode_attrs[:location_ids] = Sys::SiteCopyCheckboxes.pase_checkboxes_for_dupcms(
+          new_cmsnode_attrs[:location_ids] = Sys::SiteCopy::Checkboxes.pase_checkboxes_for_dupcms(
             node_fac_cats, "facility/location", base_cmsnode.location_ids
           )
         end

--- a/app/models/concerns/sys/site_copy/nodes.rb
+++ b/app/models/concerns/sys/site_copy/nodes.rb
@@ -1,4 +1,4 @@
-module Sys::SiteCopyNodes
+module Sys::SiteCopy::Nodes
   private
     @@node_fac_cat_routes = ["facility/location", "facility/category", "facility/service"]
     @@node_copied_fac_cat_routes = ["facility/search", "facility/node"]

--- a/app/models/concerns/sys/site_copy/roles.rb
+++ b/app/models/concerns/sys/site_copy/roles.rb
@@ -1,4 +1,4 @@
-module Sys::SiteCopyRoles
+module Sys::SiteCopy::Roles
   private
     def self.copy_roles(site_old, site)
   #権限複製：OK

--- a/app/models/concerns/sys/site_copy/templates.rb
+++ b/app/models/concerns/sys/site_copy/templates.rb
@@ -1,4 +1,4 @@
-module Sys::SiteCopyTemplates
+module Sys::SiteCopy::Templates
   private
 #テンプレート:OK
     def self.copy_templates(site_old, site)

--- a/app/models/sys/copy.rb
+++ b/app/models/sys/copy.rb
@@ -2,17 +2,17 @@ class Sys::Copy
   include ActiveModel::Model
 
 #app/models/concerns/sys/site_copy 以下にて記述
-  include Sys::SiteCopyRoles
-  include Sys::SiteCopyNodes
-  include Sys::SiteCopyCmsLayout
-  include Sys::SiteCopyCheckboxes
-  include Sys::SiteCopyCmsPages
-  include Sys::SiteCopyCmsParts
+  include Sys::SiteCopy::Roles
+  include Sys::SiteCopy::Nodes
+  include Sys::SiteCopy::CmsLayout
+  include Sys::SiteCopy::Checkboxes
+  include Sys::SiteCopy::CmsPages
+  include Sys::SiteCopy::CmsParts
 
-  include Sys::SiteCopyArticle
-  include Sys::SiteCopyFiles
-  include Sys::SiteCopyTemplates
-  include Sys::SiteCopyDictionaries
+  include Sys::SiteCopy::Article
+  include Sys::SiteCopy::Files
+  include Sys::SiteCopy::Templates
+  include Sys::SiteCopy::Dictionaries
 
   attr_accessor :name, :host, :domains, :copy_site, :copy_contents
 
@@ -38,22 +38,22 @@ class Sys::Copy
 
 #必須コピー：フォルダー、固定ページ、レイアウト、パーツ
     @layout_records_map = {}
-    @layout_records_map = Sys::SiteCopyCmsLayout.copy_cms_layout(site_old, site)
+    @layout_records_map = Sys::SiteCopy::CmsLayout.copy_cms_layout(site_old, site)
     #チェックボックス（「施設の種類」「施設の用途」「施設地域」）
-    node_fac_cats = Sys::SiteCopyCheckboxes.copy_checkboxes_for_dupcms(site_old, site, @@node_fac_cat_routes)
-    Sys::SiteCopyCheckboxes.def_fac_checkboxes_for_dupcms(site_old, site, node_fac_cats)
+    node_fac_cats = Sys::SiteCopy::Checkboxes.copy_checkboxes_for_dupcms(site_old, site, @@node_fac_cat_routes)
+    Sys::SiteCopy::Checkboxes.def_fac_checkboxes_for_dupcms(site_old, site, node_fac_cats)
     #チェックボックス（カテゴリー）
-    node_pg_cats = Sys::SiteCopyCheckboxes.copy_checkboxes_for_dupcms(site_old, site, @@node_pg_cat_routes)
+    node_pg_cats = Sys::SiteCopy::Checkboxes.copy_checkboxes_for_dupcms(site_old, site, @@node_pg_cat_routes)
     #フォルダ (uploader/file 配下で管理?するファイル含む)
-    Sys::SiteCopyNodes.copy_nodes_for_dupcms(site_old, site, node_fac_cats, @layout_records_map)
-    Sys::SiteCopyCmsPages.copy_cms_pages(site_old, site)
-    Sys::SiteCopyCmsParts.copy_cms_parts(site_old, site)
+    Sys::SiteCopy::Nodes.copy_nodes_for_dupcms(site_old, site, node_fac_cats, @layout_records_map)
+    Sys::SiteCopy::CmsPages.copy_cms_pages(site_old, site)
+    Sys::SiteCopy::CmsParts.copy_cms_parts(site_old, site)
 
 #選択コピー：記事・その他ページ、共有ファイル、テンプレート、かな辞書
-    Sys::SiteCopyArticle.copy_article(site_old, site, node_pg_cats, @layout_records_map) if params["@copy_run"]["article"] == "1"
-    Sys::SiteCopyFiles.create_dupfiles_for_dupsite(site_old, site) if params["@copy_run"]["files"] == "1"
-    Sys::SiteCopyTemplates.copy_templates(site_old, site) if params["@copy_run"]["editor_templates"] == "1"
-    Sys::SiteCopyDictionaries.copy_dictionaries(site_old, site) if params["@copy_run"]["dictionaries"] == "1"
+    Sys::SiteCopy::Article.copy_article(site_old, site, node_pg_cats, @layout_records_map) if params["@copy_run"]["article"] == "1"
+    Sys::SiteCopy::Files.create_dupfiles_for_dupsite(site_old, site) if params["@copy_run"]["files"] == "1"
+    Sys::SiteCopy::Templates.copy_templates(site_old, site) if params["@copy_run"]["editor_templates"] == "1"
+    Sys::SiteCopy::Dictionaries.copy_dictionaries(site_old, site) if params["@copy_run"]["dictionaries"] == "1"
 
   end
 end


### PR DESCRIPTION
Sys::SiteCopyXxxとなっていたモジュール名をSys::SiteCopy::Xxxと修正
