### PR TITLE
サイト複製機能 関連モジュールの修正

### DIFF
--- a/app/controllers/sys/copy_controller.rb
+++ b/app/controllers/sys/copy_controller.rb
@@ -1,7 +1,7 @@
 class Sys::CopyController < ApplicationController
   include Sys::BaseFilter
 
-#app/controllers/concerns/sys 以下にて記述
+  #app/controllers/concerns/sys 以下にて記述
   include Sys::SiteCopyValid
 
   private
@@ -22,7 +22,8 @@ class Sys::CopyController < ApplicationController
 
     def run
       Thread.start do
-        Sys::Copy.run_copy(params)
+        copy = Sys::Copy.new
+        copy.run_copy(params)
       end
     end
 end

--- a/app/models/concerns/sys/site_copy/article.rb
+++ b/app/models/concerns/sys/site_copy/article.rb
@@ -1,150 +1,151 @@
 module Sys::SiteCopy::Article
+  extend ActiveSupport::Concern
+
   private
-#記事・その他ページ
-    def self.copy_article(site_old, site, node_pg_cats, layout_records_map)
+    #記事・その他ページ
+    def copy_article(node_pg_cats, layout_records_map)
       @layout_records_map = layout_records_map
-      create_dup_banner_for_dup_site(site_old, site)      #広告バナー
-      create_dup_facility_for_dup_site(site_old, site)    #施設写真 #TODO:コピーしたレイアウトIDを適用
-      create_dup_key_visuals_for_dup_site(site_old, site) #キービジュアル
-      create_dup_cms_page2_for_dup_site(site_old, site, node_pg_cats) #その他
+      create_dup_banner_for_dup_site                  #広告バナー
+      create_dup_facility_for_dup_site                #施設写真 #TODO:コピーしたレイアウトIDを適用
+      create_dup_key_visuals_for_dup_site             #キービジュアル
+      create_dup_cms_page2_for_dup_site(node_pg_cats) #その他
     end
 
-#広告バナー
-    def self.create_dup_banner_for_dup_site(site_old, site)
-      if !site_old.kind_of?(Cms::Site) || !site.kind_of?(Cms::Site)
+    #広告バナー
+    def create_dup_banner_for_dup_site
+      if !@site_old.kind_of?(Cms::Site) || !@site.kind_of?(Cms::Site)
         logger.fatal 'Expected 2 arguments. - [0] => Cms::Site, [1] => Cms::Site'
         return false
       end
-      cms_ads = Ads::Banner.where(site_id: site_old.id).where(route: "ads/banner").order('depth ASC')
+      cms_ads = Ads::Banner.where(site_id: @site_old.id).where(route: "ads/banner").order('depth ASC')
       cms_ads.each do |cms_ad|
-          new_cms_ad = Ads::Banner.new
-           # 基本項目の情報コピー
-          new_cms_ad.attributes do |key, value|
-            if key =~ /^(_id)$/ # コピー非対象項目のフィルタリング
-              next
-            end
-            new_cms_ad[:key] = value
+        new_cms_ad = Ads::Banner.new
+         # 基本項目の情報コピー
+        new_cms_ad.attributes do |key, value|
+          if key =~ /^(_id)$/ # コピー非対象項目のフィルタリング
+            next
           end
-          # その他項目のコピーと編集
-          new_cms_ad.site_id = site.id
-          new_cms_ad.name = cms_ad.name
-          new_cms_ad.filename = cms_ad.filename
-          new_cms_ad.link_url = cms_ad.link_url
-          new_cms_ad.file_id  = clone_file(cms_ad.file_id)
-          if cms_ad.layout_id && @layout_records_map[cms_ad.layout_id]
-            new_cms_ad.layout_id = @layout_records_map[cms_ad.layout_id]
-          end
-
-          new_cms_ad.save!
+          new_cms_ad[:key] = value
         end
-    end
-
-#施設写真
-    def self.create_dup_facility_for_dup_site(site_old, site)
-        cms_facilities = Facility::Image.where(site_id: site_old.id).where(route: "facility/image")
-        cms_facilities.each do |cms_facility|
-          new_cms_facility = Facility::Image.new
-          # 基本項目の情報コピー
-          new_cms_facility.attributes do |key, value|
-            if key =~ /^(_id)$/
-              next
-            end
-            new_cms_facility[:key] = value
-          end
-          # その他項目のコピーと編集
-          new_cms_facility.site_id = site.id
-          new_cms_facility.name = cms_facility.name
-          new_cms_facility.filename = cms_facility.filename
-          new_cms_facility.layout_id = cms_facility.layout_id #TODO:コピーしたレイアウトIDを適用
-          new_cms_facility.image_id = clone_file(cms_facility.image_id)
-          if cms_facility.layout_id && @layout_records_map[cms_facility.layout_id]
-            new_cms_facility.layout_id = @layout_records_map[cms_facility.layout_id]
-          end
-          new_cms_facility.save!
-        end
-    end
-
-#キービジュアル
-    def self.create_dup_key_visuals_for_dup_site(site_old, site)
-        cms_key_visuals = KeyVisual::Image.where(site_id: site_old.id).where(route: "key_visual/image")
-        cms_key_visuals.each do |cms_key_visual|
-            new_cms_key_visual_no_attr = {}
-            new_model_attr_flag = 0
-            new_model_attr = cms_key_visual.attributes.to_hash
-            new_model_attr.delete("_id") if new_model_attr["_id"]
-            new_model_attr.keys.each do |key|
-                if !KeyVisual::Image.fields.keys.include?(key)
-                    new_model_attr_flag = 1
-                    new_cms_key_visual_no_attr.store(key, cms_key_visual[key])
-                    new_model_attr.delete("#{key}")
-                end
-            end
-            new_cms_key_visual = KeyVisual::Image.new(new_model_attr)
-            new_cms_key_visual.site_id = site.id
-
-            if new_model_attr_flag == 1
-              new_cms_key_visual_no_attr.each do |noattr, val|
-                new_cms_key_visual[noattr] = val
-              end
-            end
-
-            new_cms_key_visual.file_id = clone_file(cms_key_visual.file_id)
-            if cms_key_visual.layout_id && @layout_records_map[cms_key_visual.layout_id]
-              new_cms_key_visual.layout_id = @layout_records_map[cms_key_visual.layout_id]
-            end
-
-            new_cms_key_visual.save!
-          end
-    end
-
-#その他の記事・その他ページ
-    def self.create_dup_cms_page2_for_dup_site(site_old, site, node_pg_cats)
-        cms_pages2 = Cms::Page.where(site_id: site_old.id)
-        cms_page2_skip = ["cms/page", "ads/banner", "facility/image", "key_visual/image"]
-        cms_pages2.each do |cms_page2|
-          if cms_page2_skip.include?(cms_page2.route)
-              next
-          end
-
-          new_cms_page2_no_attr = {}
-          new_model_attr_flag = 0
-          new_model_attr = cms_page2.attributes.to_hash
-          new_model_attr.delete("_id") if new_model_attr["_id"]
-          new_model_attr.keys.each do |key|
-            if !Cms::Page.fields.keys.include?(key)
-              new_model_attr_flag = 1
-              new_cms_page2_no_attr.store(key, cms_page2[key])
-              new_model_attr.delete("#{key}")
-            end
-          end
-          new_cms_page2 = Cms::Page.new(new_model_attr)
-          new_cms_page2.site_id = site.id
-
-          if new_model_attr_flag == 1
-            new_cms_page2_no_attr.each do |noattr, val|
-              new_cms_page2[noattr] = val
-            end
-          end
-
-          files_param = clone_files(cms_page2.file_ids, cms_page2.html)
-          new_cms_page2["file_ids"] = files_param["file_ids"]
-          new_cms_page2["html"] = files_param["html"]
-
-          if cms_page2.layout_id && @layout_records_map[cms_page2.layout_id]
-            new_cms_page2.layout_id = @layout_records_map[cms_page2.layout_id]
-          end
-
-          if cms_page2.route == "facility/page"
-            new_cms_page2.category_ids = Sys::SiteCopy::Checkboxes.pase_checkboxes_for_dupcms(node_pg_cats, "merge", cms_page2.category_ids)
-          end
-
-          new_cms_page2.save!
+        # その他項目のコピーと編集
+        new_cms_ad.site_id = @site.id
+        new_cms_ad.name = cms_ad.name
+        new_cms_ad.filename = cms_ad.filename
+        new_cms_ad.link_url = cms_ad.link_url
+        new_cms_ad.file_id  = clone_file(cms_ad.file_id)
+        if cms_ad.layout_id && @layout_records_map[cms_ad.layout_id]
+          new_cms_ad.layout_id = @layout_records_map[cms_ad.layout_id]
         end
 
+        new_cms_ad.save!
+      end
     end
 
-# ファイルを複製しファイルidを返す(単体)
-    def self.clone_file(old_file_id)
+    #施設写真
+    def create_dup_facility_for_dup_site
+      cms_facilities = Facility::Image.where(site_id: @site_old.id).where(route: "facility/image")
+      cms_facilities.each do |cms_facility|
+        new_cms_facility = Facility::Image.new
+        # 基本項目の情報コピー
+        new_cms_facility.attributes do |key, value|
+          if key =~ /^(_id)$/
+            next
+          end
+          new_cms_facility[:key] = value
+        end
+        # その他項目のコピーと編集
+        new_cms_facility.site_id = @site.id
+        new_cms_facility.name = cms_facility.name
+        new_cms_facility.filename = cms_facility.filename
+        new_cms_facility.layout_id = cms_facility.layout_id #TODO:コピーしたレイアウトIDを適用
+        new_cms_facility.image_id = clone_file(cms_facility.image_id)
+        if cms_facility.layout_id && @layout_records_map[cms_facility.layout_id]
+          new_cms_facility.layout_id = @layout_records_map[cms_facility.layout_id]
+        end
+        new_cms_facility.save!
+      end
+    end
+
+    #キービジュアル
+    def create_dup_key_visuals_for_dup_site
+      cms_key_visuals = KeyVisual::Image.where(site_id: @site_old.id).where(route: "key_visual/image")
+      cms_key_visuals.each do |cms_key_visual|
+        new_cms_key_visual_no_attr = {}
+        new_model_attr_flag = 0
+        new_model_attr = cms_key_visual.attributes.to_hash
+        new_model_attr.delete("_id") if new_model_attr["_id"]
+        new_model_attr.keys.each do |key|
+          if !KeyVisual::Image.fields.keys.include?(key)
+            new_model_attr_flag = 1
+            new_cms_key_visual_no_attr.store(key, cms_key_visual[key])
+            new_model_attr.delete("#{key}")
+          end
+        end
+        new_cms_key_visual = KeyVisual::Image.new(new_model_attr)
+        new_cms_key_visual.site_id = @site.id
+
+        if new_model_attr_flag == 1
+          new_cms_key_visual_no_attr.each do |noattr, val|
+            new_cms_key_visual[noattr] = val
+          end
+        end
+
+        new_cms_key_visual.file_id = clone_file(cms_key_visual.file_id)
+        if cms_key_visual.layout_id && @layout_records_map[cms_key_visual.layout_id]
+          new_cms_key_visual.layout_id = @layout_records_map[cms_key_visual.layout_id]
+        end
+
+        new_cms_key_visual.save!
+      end
+    end
+
+    #その他の記事・その他ページ
+    def create_dup_cms_page2_for_dup_site(node_pg_cats)
+      cms_pages2 = Cms::Page.where(site_id: @site_old.id)
+      cms_page2_skip = ["cms/page", "ads/banner", "facility/image", "key_visual/image"]
+      cms_pages2.each do |cms_page2|
+        if cms_page2_skip.include?(cms_page2.route)
+            next
+        end
+
+        new_cms_page2_no_attr = {}
+        new_model_attr_flag = 0
+        new_model_attr = cms_page2.attributes.to_hash
+        new_model_attr.delete("_id") if new_model_attr["_id"]
+        new_model_attr.keys.each do |key|
+          if !Cms::Page.fields.keys.include?(key)
+            new_model_attr_flag = 1
+            new_cms_page2_no_attr.store(key, cms_page2[key])
+            new_model_attr.delete("#{key}")
+          end
+        end
+        new_cms_page2 = Cms::Page.new(new_model_attr)
+        new_cms_page2.site_id = @site.id
+
+        if new_model_attr_flag == 1
+          new_cms_page2_no_attr.each do |noattr, val|
+            new_cms_page2[noattr] = val
+          end
+        end
+
+        files_param = clone_files(cms_page2.file_ids, cms_page2.html)
+        new_cms_page2["file_ids"] = files_param["file_ids"]
+        new_cms_page2["html"] = files_param["html"]
+
+        if cms_page2.layout_id && @layout_records_map[cms_page2.layout_id]
+          new_cms_page2.layout_id = @layout_records_map[cms_page2.layout_id]
+        end
+
+        if cms_page2.route == "facility/page"
+          new_cms_page2.category_ids = Sys::SiteCopy::Checkboxes.pase_checkboxes_for_dupcms(node_pg_cats, "merge", cms_page2.category_ids)
+        end
+
+        new_cms_page2.save!
+      end
+    end
+
+    # ファイルを複製しファイルidを返す(単体)
+    def clone_file(old_file_id)
       old_file = SS::File.find(old_file_id)
       attributes = Hash[old_file.attributes]
       attributes.select!{ |k| old_file.fields.keys.include?(k) }
@@ -158,8 +159,8 @@ module Sys::SiteCopy::Article
       return file.id.mongoize
     end
 
-# ファイルを複製しファイルidなどを返す(複数)
-    def self.clone_files(old_file_ids, html)
+    # ファイルを複製しファイルidなどを返す(複数)
+    def clone_files(old_file_ids, html)
       return_param = {}
       return_param["file_ids"] = []
       return_param["html"] = html
@@ -178,10 +179,9 @@ module Sys::SiteCopy::Article
         file.save validate: false
         return_param["file_ids"].push(file.id.mongoize)
 
-# NOTE:trだと複数ファイルコピー時にURL置換の挙動がおかしい（本来ファイルAを指すパスをファイルBのパスで書き換えている）
+        # NOTE:trだと複数ファイルコピー時にURL置換の挙動がおかしい（本来ファイルAを指すパスをファイルBのパスで書き換えている）
         return_param["html"].gsub!("=\"#{old_file.url}\"", "=\"#{file.url}\"")
       end
       return return_param
     end
-
 end

--- a/app/models/concerns/sys/site_copy/checkboxes.rb
+++ b/app/models/concerns/sys/site_copy/checkboxes.rb
@@ -1,11 +1,12 @@
 module Sys::SiteCopy::Checkboxes
+  extend ActiveSupport::Concern
   private
     @@node_fac_cat_routes = ["facility/location", "facility/category", "facility/service"]
     @@node_copied_fac_cat_routes = ["facility/search", "facility/node"]
     @@node_pg_cat_routes = ["category/node", "category/page"]
 
-    def self.copy_checkboxes_for_dupcms(base_site, new_site, routes)
-      if !base_site.kind_of?(Cms::Site) || !new_site.kind_of?(Cms::Site)
+    def copy_checkboxes_for_dupcms(routes)
+      if !@site_old.kind_of?(Cms::Site) || !@site.kind_of?(Cms::Site)
         logger.fatal 'Expected 2 arguments. - [0] => Cms::Site, [1] => Cms::Site'
         return false
       end
@@ -14,7 +15,7 @@ module Sys::SiteCopy::Checkboxes
       node_cats.store("merge", {})
       routes.each do |node_cat_route|
         node_cats.store(node_cat_route, {})
-        Cms::Node.where(:site_id => base_site.id).where(route: node_cat_route).each do |base_cmsnode|
+        Cms::Node.where(:site_id => @site_old.id).where(route: node_cat_route).each do |base_cmsnode|
 
           old_cmsnode_id = base_cmsnode.id
           new_cmsnode_no_attr = {}
@@ -29,7 +30,7 @@ module Sys::SiteCopy::Checkboxes
             end
           end
           new_cmsnode = Cms::Node.new(new_model_attr)
-          new_cmsnode.site_id = new_site.id
+          new_cmsnode.site_id = @site.id
 
           if new_model_attr_flag == 1
             new_cmsnode_no_attr.each do |noattr, val|
@@ -45,8 +46,8 @@ module Sys::SiteCopy::Checkboxes
       return node_cats
     end
 
-    def self.def_fac_checkboxes_for_dupcms(base_site, new_site, node_fac_cats)
-      if !base_site.kind_of?(Cms::Site) || !new_site.kind_of?(Cms::Site)
+    def def_fac_checkboxes_for_dupcms(node_fac_cats)
+      if !@site_old.kind_of?(Cms::Site) || !@site.kind_of?(Cms::Site)
         logger.fatal 'Expected 2 arguments. - [0] => Cms::Site, [1] => Cms::Site'
         return false
       end
@@ -58,7 +59,7 @@ module Sys::SiteCopy::Checkboxes
         end
       end
       @@node_copied_fac_cat_routes.each do |node_copied_cat_route|
-        Cms::Node.where(:site_id => base_site.id).where(route: node_copied_cat_route).each do |base_cmsnode|
+        Cms::Node.where(:site_id => @site_old.id).where(route: node_copied_cat_route).each do |base_cmsnode|
           old_cmsnode_id = base_cmsnode.id
           new_cmsnode_no_attr = {}
           new_model_attr_flag = 0
@@ -72,7 +73,7 @@ module Sys::SiteCopy::Checkboxes
             end
           end
           new_cmsnode = Cms::Node.new(new_model_attr)
-          new_cmsnode.site_id = new_site.id
+          new_cmsnode.site_id = @site.id
 
           if new_model_attr_flag == 1
             new_cmsnode_no_attr.each do |noattr, val|
@@ -89,7 +90,7 @@ module Sys::SiteCopy::Checkboxes
       end
     end
 
-    def self.pase_checkboxes_for_dupcms(ary, key, old_ids)
+    def pase_checkboxes_for_dupcms(ary, key, old_ids)
       chk_param = []
       old_ids.each do |old_id|
         chk_param.push(ary[key][old_id])

--- a/app/models/concerns/sys/site_copy/cms_layout.rb
+++ b/app/models/concerns/sys/site_copy/cms_layout.rb
@@ -1,15 +1,17 @@
 module Sys::SiteCopy::CmsLayout
+  extend ActiveSupport::Concern
+
   private
     @layout_records_map = {}
-#レイアウト:OK
-# NOTE: 20160301 - Cms::Node は "layout_id" を持つため "レイアウト" よりも後に処理を行うべきなので処理の順序を変更
+    #レイアウト:OK
+    # NOTE: 20160301 - Cms::Node は "layout_id" を持つため "レイアウト" よりも後に処理を行うべきなので処理の順序を変更
     # 新旧レイアウトレコードIDのKeyVal
     # ex) {<BaseLayoutID>: <DupLayoutID>[, ...]}
-    def self.copy_cms_layout(site_old, site)
-      Cms::Layout.where(site_id: site_old.id).each do |cms_layout|
+    def copy_cms_layout
+      Cms::Layout.where(site_id: @site_old.id).each do |cms_layout|
         new_cms_layout = Cms::Layout.new
         new_cms_layout = cms_layout.dup
-        new_cms_layout.site_id = site.id
+        new_cms_layout.site_id = @site.id
         if new_cms_layout.save
           @layout_records_map[cms_layout.id] = new_cms_layout.id
         end

--- a/app/models/concerns/sys/site_copy/cms_pages.rb
+++ b/app/models/concerns/sys/site_copy/cms_pages.rb
@@ -1,12 +1,12 @@
 module Sys::SiteCopy::CmsPages
   private
-#固定ページ:OK
-    def self.copy_cms_pages(site_old, site)
-      cms_pages = Cms::Page.where(site_id: site_old.id, route: "cms/page")
+    #固定ページ:OK
+    def copy_cms_pages
+      cms_pages = Cms::Page.where(site_id: @site_old.id, route: "cms/page")
       cms_pages.each do |cms_page|
         new_cms_page = Cms::Page.new
         new_cms_page = cms_page.dup
-        new_cms_page.site_id = site.id
+        new_cms_page.site_id = @site.id
         new_cms_page.save
       end
     end

--- a/app/models/concerns/sys/site_copy/cms_parts.rb
+++ b/app/models/concerns/sys/site_copy/cms_parts.rb
@@ -1,9 +1,11 @@
 module Sys::SiteCopy::CmsParts
+  extend ActiveSupport::Concern
+
   private
-#パーツ:OK
-# NOTE:cms_part.dup だと失敗する
-    def self.copy_cms_parts(site_old, site)
-      cms_parts = Cms::Part.where(site_id: site_old.id)
+    #パーツ:OK
+    # NOTE:cms_part.dup だと失敗する
+    def copy_cms_parts
+      cms_parts = Cms::Part.where(site_id: @site_old.id)
       cms_parts.each do |cms_part|
         new_cms_part_no_attr = {}
         new_model_attr_flag = 0
@@ -17,7 +19,7 @@ module Sys::SiteCopy::CmsParts
           end
         end
         new_cms_part = Cms::Part.new(new_model_attr)
-        new_cms_part.site_id = site.id
+        new_cms_part.site_id = @site.id
 
         if new_model_attr_flag == 1
           new_cms_part_no_attr.each do |noattr, val|

--- a/app/models/concerns/sys/site_copy/dictionaries.rb
+++ b/app/models/concerns/sys/site_copy/dictionaries.rb
@@ -1,12 +1,14 @@
 module Sys::SiteCopy::Dictionaries
+  extend ActiveSupport::Concern
+
   private
-#かな辞書:OK
-    def self.copy_dictionaries(site_old, site)
-      kana_dictionaries = Kana::Dictionary.where(site_id: site_old.id)
+    #かな辞書:OK
+    def copy_dictionaries
+      kana_dictionaries = Kana::Dictionary.where(site_id: @site_old.id)
       kana_dictionaries.each do |kana_dictionary|
         new_kana_dictionary = Kana::Dictionary.new
         new_kana_dictionary = kana_dictionary.dup
-        new_kana_dictionary.site_id = site.id
+        new_kana_dictionary.site_id = @site.id
         new_kana_dictionary.save
       end
     end

--- a/app/models/concerns/sys/site_copy/nodes.rb
+++ b/app/models/concerns/sys/site_copy/nodes.rb
@@ -1,4 +1,6 @@
 module Sys::SiteCopy::Nodes
+  extend ActiveSupport::Concern
+
   private
     @@node_fac_cat_routes = ["facility/location", "facility/category", "facility/service"]
     @@node_copied_fac_cat_routes = ["facility/search", "facility/node"]
@@ -11,8 +13,6 @@ module Sys::SiteCopy::Nodes
     #   * Cms::Node で指定される path (ディレクトリ)
     #   * Cms::Node で指定される path 配下のファイル全て
     #
-    # @param  {Cms::Site} base_site
-    # @param  {Cms::Site} new_site
     ###
     # Cms::Node.new に必要な材料 (1レコード分)
     #   * permission_level ... 複製元と同じもの
@@ -31,15 +31,15 @@ module Sys::SiteCopy::Nodes
     #   * cur_site ........... 複製元サイト (Cms::Site)
     #   * cur_node ........... 親となるフォルダ Cms::Node (無い場合は false)
 
-    def self.copy_nodes_for_dupcms(base_site, new_site, node_fac_cats, layout_records_map)
+    def copy_nodes_for_dupcms(node_fac_cats, layout_records_map)
       # 新サイト用の public 配下ディレクトリ
       # ex: /var/www/shirasagi/public/sites/h/o/s/t/n/a/m/e
-      basesite_public_dir = Rails.public_path.to_s+'/sites/'+(base_site.host.split('').join('/'))+'/_'
-      site_public_dir     = Rails.public_path.to_s+'/sites/'+(new_site.host.split('').join('/'))+'/_'
+      basesite_public_dir = Rails.public_path.to_s+'/sites/'+(@site_old.host.split('').join('/'))+'/_'
+      site_public_dir     = Rails.public_path.to_s+'/sites/'+(@site.host.split('').join('/'))+'/_'
       @layout_records_map = layout_records_map
 
       # 階層の浅い物から実施
-      Cms::Node.where(:site_id => base_site.id).order('depth ASC').each do |base_cmsnode|
+      Cms::Node.where(:site_id => @site_old.id).order('depth ASC').each do |base_cmsnode|
         next if @@node_fac_cat_routes.include?(base_cmsnode.route)
         next if @@node_copied_fac_cat_routes.include?(base_cmsnode.route)
         next if @@node_pg_cat_routes.include?(base_cmsnode.route)
@@ -62,7 +62,7 @@ module Sys::SiteCopy::Nodes
           new_cmsnode_no_attr.store(key, base_cmsnode[key]) if !Cms::Node.fields.keys.include?(key)
         end
 
-        new_cmsnode_attrs = set_cstm_attrs(base_cmsnode, new_site, node_fac_cats, new_cmsnode_attrs)
+        new_cmsnode_attrs = set_cstm_attrs(base_cmsnode, node_fac_cats, new_cmsnode_attrs)
 
         # レコードモデル生成
         cms_node_obj = Cms::Node.new new_cmsnode_attrs
@@ -76,7 +76,7 @@ module Sys::SiteCopy::Nodes
       end
     end
 
-    def self.copy_file_dir(base_cmsnode, basesite_public_dir, site_public_dir)
+    def copy_file_dir(base_cmsnode, basesite_public_dir, site_public_dir)
       # ディレクトリ複製
       cur_dirname   = base_cmsnode.filename
       base_dir_path = basesite_public_dir+'/'+cur_dirname
@@ -99,11 +99,11 @@ module Sys::SiteCopy::Nodes
       end
     end
 
-    def self.calc_cur_node(base_cmsnode, new_site)
+    def calc_cur_node(base_cmsnode)
       parent_node_depth    = base_cmsnode.depth-1
       parent_node_filename = base_cmsnode.filename.split('/').delete_at(parent_node_depth) if base_cmsnode.filename
       search_params = {
-        site_id:  new_site.id,
+        site_id:  @site.id,
         depth:    parent_node_depth,
         filename: parent_node_filename
       }
@@ -117,34 +117,34 @@ module Sys::SiteCopy::Nodes
       new_cmsnode_attrs[:cur_node] = res_search_parent_node.first if res_search_parent_node.size == 1
     end
 
-    def self.set_cstm_attrs(base_cmsnode, new_site, node_fac_cats, new_cmsnode_attrs)
-        # 施設の種類・用途・地域
-        if base_cmsnode.route == "facility/page"
-          new_cmsnode_attrs[:category_ids] = Sys::SiteCopy::Checkboxes.pase_checkboxes_for_dupcms(
-            node_fac_cats, "facility/category", base_cmsnode.category_ids
-          )
-          new_cmsnode_attrs[:service_ids] = Sys::SiteCopy::Checkboxes.pase_checkboxes_for_dupcms(
-            node_fac_cats, "facility/service", base_cmsnode.service_ids
-          )
-          new_cmsnode_attrs[:location_ids] = Sys::SiteCopy::Checkboxes.pase_checkboxes_for_dupcms(
-            node_fac_cats, "facility/location", base_cmsnode.location_ids
-          )
-        end
-        # 紐付くサイト
-        new_cmsnode_attrs[:cur_site] = new_site
-        # フォルダを作成したユーザー or false
-        new_cmsnode_attrs[:cur_user] = base_cmsnode.user_id ? Cms::User.find(base_cmsnode.user_id) : false
-        # レイアウトID
-        if base_cmsnode.layout_id && @layout_records_map[base_cmsnode.layout_id]
-          new_cmsnode_attrs[:layout_id] = @layout_records_map[base_cmsnode.layout_id]
-        end
-        # ページレイアウトID
-        if base_cmsnode.page_layout_id && @layout_records_map[base_cmsnode.page_layout_id]
-          new_cmsnode_attrs[:page_layout_id] = @layout_records_map[base_cmsnode.page_layout_id]
-        end
-        # 親 Cms::Node 必要なら取得 (2階層以上の深さある場合)
-        calc_cur_node(base_cmsnode, new_site) if base_cmsnode.cur_node && 1 < base_cmsnode.depth
-        return new_cmsnode_attrs
+    def set_cstm_attrs(base_cmsnode, node_fac_cats, new_cmsnode_attrs)
+      # 施設の種類・用途・地域
+      if base_cmsnode.route == "facility/page"
+        new_cmsnode_attrs[:category_ids] = pase_checkboxes_for_dupcms(
+          node_fac_cats, "facility/category", base_cmsnode.category_ids
+        )
+        new_cmsnode_attrs[:service_ids] = pase_checkboxes_for_dupcms(
+          node_fac_cats, "facility/service", base_cmsnode.service_ids
+        )
+        new_cmsnode_attrs[:location_ids] = pase_checkboxes_for_dupcms(
+          node_fac_cats, "facility/location", base_cmsnode.location_ids
+        )
+      end
+      # 紐付くサイト
+      new_cmsnode_attrs[:cur_site] = @site
+      # フォルダを作成したユーザー or false
+      new_cmsnode_attrs[:cur_user] = base_cmsnode.user_id ? Cms::User.find(base_cmsnode.user_id) : false
+      # レイアウトID
+      if base_cmsnode.layout_id && @layout_records_map[base_cmsnode.layout_id]
+        new_cmsnode_attrs[:layout_id] = @layout_records_map[base_cmsnode.layout_id]
+      end
+      # ページレイアウトID
+      if base_cmsnode.page_layout_id && @layout_records_map[base_cmsnode.page_layout_id]
+        new_cmsnode_attrs[:page_layout_id] = @layout_records_map[base_cmsnode.page_layout_id]
+      end
+      # 親 Cms::Node 必要なら取得 (2階層以上の深さある場合)
+      calc_cur_node(base_cmsnode) if base_cmsnode.cur_node && 1 < base_cmsnode.depth
+      return new_cmsnode_attrs
     end
 
 end

--- a/app/models/concerns/sys/site_copy/roles.rb
+++ b/app/models/concerns/sys/site_copy/roles.rb
@@ -1,18 +1,20 @@
 module Sys::SiteCopy::Roles
+  extend ActiveSupport::Concern
+
   private
-    def self.copy_roles(site_old, site)
-  #権限複製：OK
-      cms_roles = Cms::Role.where(site_id: site_old.id)
+    def copy_roles
+      #権限複製：OK
+      cms_roles = Cms::Role.where(site_id: @site_old.id)
       new_cms_roles_id = {}
       cms_roles.each do |cms_role|
         new_cms_role = Cms::Role.new
         new_cms_role = cms_role.dup
-        new_cms_role.site_id = site.id
+        new_cms_role.site_id = @site.id
         new_cms_role.save
         new_cms_roles_id.store(cms_role.id, new_cms_role.id)
       end
 
-  #ユーザへ新規権限付与：OK
+      #ユーザへ新規権限付与：OK
       new_cms_roles_id.each do |old_role_id, new_role_id|
         cms_users = Cms::User.where(cms_role_ids: old_role_id)
         cms_users.each do |cms_user|

--- a/app/models/concerns/sys/site_copy/templates.rb
+++ b/app/models/concerns/sys/site_copy/templates.rb
@@ -1,12 +1,14 @@
 module Sys::SiteCopy::Templates
+  extend ActiveSupport::Concern
+
   private
-#テンプレート:OK
-    def self.copy_templates(site_old, site)
-      cms_templates = Cms::EditorTemplate.where(site_id: site_old.id)
+    #テンプレート:OK
+    def copy_templates
+      cms_templates = Cms::EditorTemplate.where(site_id: @site_old.id)
       cms_templates.each do |cms_template|
         new_cms_template = Cms::EditorTemplate.new
         new_cms_template = cms_template.dup
-        new_cms_template.site_id = site.id
+        new_cms_template.site_id = @site.id
         new_cms_template.save
       end
     end


### PR DESCRIPTION
クラスメソッドをプラベートなインスタンスメソッドに変更
各メソッドの引数を省略し、インスタンス変数を参照するように
インデントの修正
Sys::Copyのrun_copyメソッドをインスタンスメソッドに変更
