### PR TITLE
サイト複製関連の修正対応

### DIFF
--- a/app/models/concerns/sys/site_copy/article.rb
+++ b/app/models/concerns/sys/site_copy/article.rb
@@ -146,8 +146,10 @@ module Sys::SiteCopy::Article
                                                                  cms_page2.category_ids)
         end
 
+        new_cms_page2.body_parts = cms_page2.body_parts if defined? new_cms_page2.body_parts
+
         begin
-          new_cms_page2.save!
+          new_cms_page2.save! validate: false
         rescue => exception
           Rails.logger.error(exception.message)
           throw exception


### PR DESCRIPTION
https://github.com/shirasagi/shirasagi/pull/873#issuecomment-214655172
複製されたページの保存時にバリデーターが走り、そこでエラーが発生してページが保存できずにいた。
当方にて下手にバリデーターにコピー処理用の分岐を入れるよりは良さそうだったので、ひとまず「validate:false」を使っています。

body_partsがコピーできていなかったのを修正
